### PR TITLE
NCO Crashing Fix

### DIFF
--- a/factions/brown.xml
+++ b/factions/brown.xml
@@ -650,7 +650,7 @@
 	<!-- --- -->
 	<!-- NCO -->
 	<!-- --- -->
-	<soldier name="NCO" spawn_score="0.06">
+	<soldier name="nco" spawn_score="0.06">
 		<character filename="default_male.character" />
 		<ai filename="elite.ai" />
 		

--- a/factions/grey.xml
+++ b/factions/grey.xml
@@ -676,7 +676,7 @@
 	<!-- --- -->
 	<!-- NCO -->
 	<!-- --- -->
-	<soldier name="NCO" spawn_score="0.06">
+	<soldier name="nco" spawn_score="0.06">
 		<character filename="default_male.character" />
 		<ai filename="elite.ai" />
 		


### PR DESCRIPTION
- Corrected inconsistency in soldier names in the faction XMLs pointed out by Mr. Bang, should solve weird crashing whenever GL humvee showed up on screen