### PR TITLE
Changes to AI Weapon Inventories

### DIFF
--- a/factions/common_eod.resources
+++ b/factions/common_eod.resources
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources clear_weapons="1">
+	<!-- always load common first; it's the one that clears the initial weapon resources -->
+
+	<weapon key='uts15.weapon' />
+  
+	<weapon key='benelli_m4.weapon' />
+	<weapon key='pepperdust.weapon' />
+	<weapon key='ns2000.weapon' />
+	<weapon key='aa-12.weapon' />
+	<weapon key='jackhammer.weapon' />
+	<weapon key='flamethrower.weapon' />
+	<weapon key='aa12_frag.weapon' />
+	<weapon key="dragons_breath.weapon" />
+			
+	<weapon key='riot_shield.weapon' />
+	<weapon key='tti_ai.weapon' />
+	
+
+	<carry_item key='vest1.carry_item' enabled="0" />
+	<carry_item key='vest2.carry_item' enabled="0" />
+	<carry_item key='vest3.carry_item' enabled="0" />
+	<carry_item key='eodvest.carry_item' enabled="0" />
+	<carry_item key='eodvest_ai.carry_item' enabled="1" />
+  
+	<projectile key='hand_grenade.projectile' enabled="0" />
+	<projectile key='impact_grenade.projectile' enabled="0" />
+	<projectile key='stun_grenade.projectile' enabled="1" />    
+
+<!-- CB#6 -->
+	<carry_item key='dog.carry_item' enabled="0" />
+	<carry_item key='ugv.carry_item' enabled="0" />
+	<projectile key='selfstun.projectile' enabled="0" />      
+  
+</resources>

--- a/factions/common_grenadier.resources
+++ b/factions/common_grenadier.resources
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources clear_weapons="1">
+	<!-- always load common first; it's the one that clears the initial weapon resources -->
+
+	<!-- <weapon key='cover_resource.weapon' /> -->
+	<weapon key='stoner_lmg_ai.weapon' />
+
+	<carry_item key='vest1.carry_item' enabled="0" />
+	<carry_item key='vest2.carry_item' enabled="0" />
+	<carry_item key='vest3.carry_item' enabled="0" />
+	<carry_item key='eodvest.carry_item' enabled="1" />
+	<carry_item key='eodvest_ai.carry_item' enabled="0" />
+
+  
+	<projectile key='hand_grenade.projectile' enabled="0" />
+	<projectile key='impact_grenade.projectile' enabled="0" />
+	<projectile key='stun_grenade.projectile' enabled="0" />    
+
+<!-- CB#6 -->
+	<carry_item key='dog.carry_item' enabled="0" />
+	<carry_item key='ugv.carry_item' enabled="0" />
+	<projectile key='selfstun.projectile' enabled="0" />      
+  
+</resources>

--- a/factions/common_grenadier.resources
+++ b/factions/common_grenadier.resources
@@ -3,6 +3,11 @@
 	<!-- always load common first; it's the one that clears the initial weapon resources -->
 
 	<!-- <weapon key='cover_resource.weapon' /> -->
+	<weapon key='mgl_flasher.weapon' />
+	<weapon key='milkor_mgl.weapon' />
+	<weapon key='paw20.weapon' />
+	<weapon key='xm25.weapon' />
+	
 	<weapon key='stoner_lmg_ai.weapon' />
 
 	<carry_item key='vest1.carry_item' enabled="0" />

--- a/factions/common_miniboss.resources
+++ b/factions/common_miniboss.resources
@@ -9,7 +9,7 @@
 
 	<weapon key='stoner_lmg.weapon' />
 
-	<weapon key='mgl_flasher.weapon' /> 
+	<!-- <weapon key='mgl_flasher.weapon' /> -->
 	<weapon key='barrett_m107.weapon' />
 	<weapon key='xm8.weapon' /> 
 	<weapon key='microgun.weapon' /> 
@@ -17,13 +17,13 @@
 <!--	<weapon key='benelli_m4_supp.weapon' />  -->
 	<weapon key='mg42.weapon' /> 
 	<weapon key='lahti_l39.weapon' />  
-	<weapon key='milkor_mgl.weapon' /> 
+	<!-- <weapon key='milkor_mgl.weapon' /> -->
 	<weapon key='m202_flash.weapon' /> 
 	<weapon key='steyr_aug.weapon' />
 	<weapon key='scarssr.weapon' />  
 	<weapon key='chain_saw.weapon' /> 
 	<weapon key='pecheneg_bullpup.weapon' />
-	<weapon key='paw20.weapon' />   
+	<!-- <weapon key='paw20.weapon' /> -->
 	<weapon key='stoner62.weapon' />     
    
 

--- a/factions/common_miniboss.resources
+++ b/factions/common_miniboss.resources
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources clear_weapons="1">
+	<!-- always load common first; it's the one that clears the initial weapon resources -->
+	<weapon key='p90.weapon' />
+
+	<weapon key='f2000.weapon' />
+	<weapon key='aks74u.weapon' />
+	<weapon key='vss_vintorez.weapon' />
+
+	<weapon key='stoner_lmg.weapon' />
+
+	<weapon key='mgl_flasher.weapon' /> 
+	<weapon key='barrett_m107.weapon' />
+	<weapon key='xm8.weapon' /> 
+	<weapon key='microgun.weapon' /> 
+	<weapon key='kriss_vector.weapon' />
+<!--	<weapon key='benelli_m4_supp.weapon' />  -->
+	<weapon key='mg42.weapon' /> 
+	<weapon key='lahti_l39.weapon' />  
+	<weapon key='milkor_mgl.weapon' /> 
+	<weapon key='m202_flash.weapon' /> 
+	<weapon key='steyr_aug.weapon' />
+	<weapon key='scarssr.weapon' />  
+	<weapon key='chain_saw.weapon' /> 
+	<weapon key='pecheneg_bullpup.weapon' />
+	<weapon key='paw20.weapon' />   
+	<weapon key='stoner62.weapon' />     
+   
+
+	<carry_item key='vest1.carry_item' enabled="0" />			
+	<carry_item key='vest2.carry_item' enabled="0" />
+	<carry_item key='vest3.carry_item' enabled="1" />
+	<carry_item key='eodvest.carry_item' enabled="0" />
+	<carry_item key='eodvest_ai.carry_item' enabled="0" />
+  
+
+<!-- CB#6 -->
+	<carry_item key='dog.carry_item' enabled="0" />
+	<carry_item key='ugv.carry_item' enabled="0" />
+	<projectile key='selfstun.projectile' enabled="0" />      
+</resources>

--- a/factions/common_miniboss.resources
+++ b/factions/common_miniboss.resources
@@ -5,26 +5,44 @@
 
 	<weapon key='f2000.weapon' />
 	<weapon key='aks74u.weapon' />
-	<weapon key='vss_vintorez.weapon' />
-
-	<weapon key='stoner_lmg.weapon' />
-
-	<!-- <weapon key='mgl_flasher.weapon' /> -->
-	<weapon key='barrett_m107.weapon' />
 	<weapon key='xm8.weapon' /> 
-	<weapon key='microgun.weapon' /> 
-	<weapon key='kriss_vector.weapon' />
-<!--	<weapon key='benelli_m4_supp.weapon' />  -->
-	<weapon key='mg42.weapon' /> 
-	<weapon key='lahti_l39.weapon' />  
-	<!-- <weapon key='milkor_mgl.weapon' /> -->
-	<weapon key='m202_flash.weapon' /> 
 	<weapon key='steyr_aug.weapon' />
-	<weapon key='scarssr.weapon' />  
+	<weapon key='g3_1x.weapon' />
+	<weapon key='g3_3x.weapon' />
+	<weapon key='tkb059.weapon' />
+	<weapon key='fal.weapon' />
+	<weapon key='fal_bayonet.weapon' />
+	<weapon key='honey_badger.weapon' />
+	<weapon key='p416.weapon' />
+	
+	<!-- <weapon key='vss_vintorez.weapon' /> -->
+	<weapon key='scarssr.weapon' />
+	<weapon key='barrett_m107.weapon' />
+	<weapon key='lahti_l39.weapon' /> 
+	<weapon key='fd338.weapon' />
+	<weapon key='enforcer.weapon' />
+	
+	<weapon key='stoner_lmg.weapon' />
+	<weapon key='stoner62.weapon' /> 
+	<weapon key='microgun.weapon' />
 	<weapon key='chain_saw.weapon' /> 
 	<weapon key='pecheneg_bullpup.weapon' />
-	<!-- <weapon key='paw20.weapon' /> -->
-	<weapon key='stoner62.weapon' />     
+	<weapon key='mg42.weapon' /> 
+	<weapon key='m16a4_support.weapon' />
+	<weapon key='m60e4.weapon' />
+	<weapon key='ares_shrike.weapon' />
+	<weapon key='dp28.weapon' />
+	<weapon key='dp28_s.weapon' />
+	
+	<weapon key='kriss_vector.weapon' />
+	<weapon key='suomi.weapon' />
+	<!-- <weapon key='benelli_m4_supp.weapon' /> -->
+	
+	<weapon key='m202_flash.weapon' /> 
+
+	<!-- <weapon key='mgl_flasher.weapon' />
+	<weapon key='milkor_mgl.weapon' />
+	<weapon key='paw20.weapon' /> -->    
    
 
 	<carry_item key='vest1.carry_item' enabled="0" />			

--- a/factions/lonewolf_sniper.resources
+++ b/factions/lonewolf_sniper.resources
@@ -2,6 +2,8 @@
 <resources clear_weapons="1" clear_vehicles="1" clear_grenades="1" clear_carry_items="1" clear_calls="1">
 	<weapon key='apr.weapon' />
 	<weapon key='gepard_m6_lynx.weapon' />
+	<weapon key='fd338sd.weapon' />
+	<weapon key='vss_vintorez.weapon' />
 
 	<carry_item key='camouflage_suit.carry_item' />
 

--- a/factions/lonewolf_sniper.resources
+++ b/factions/lonewolf_sniper.resources
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources clear_weapons="1" clear_vehicles="1" clear_grenades="1" clear_carry_items="1" clear_calls="1">
+	<weapon key='apr.weapon' />
+	<weapon key='gepard_m6_lynx.weapon' />
+
+	<carry_item key='camouflage_suit.carry_item' />
+
+	<call key='mortar1.call' />
+	<call key='paratroopers_medic.call' />
+</resources>

--- a/weapons/aa12_frag.weapon
+++ b/weapons/aa12_frag.weapon
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<weapon file="base_primary_rare.weapon" key="aa12_frag.weapon" on_ground_up="0 0 1" >
+<tag name="cqb" />
+    <specification retrigger_time="0.3" 
+    accuracy_factor="0.9" 
+    spread_range="0.2"
+    sustained_fire_grow_step="0.35" 
+    sustained_fire_diminish_rate="0.85" 
+    magazine_size="20" 
+    can_shoot_standing="1" 
+    suppressed="0" 
+    name="AA-12 Frag" 
+    class="0" 
+    reload_one_at_a_time="0" 
+    sight_range_modifier="1.0" 
+    projectile_speed="75.0" 
+    projectiles_per_shot="1" />
+    <animation key="recoil" ref="27" />
+    <animation key="cycle" ref="28" />
+    <animation key="reload" animation_key="reloading, aa-12" />
+	<animation key="reload" stance_key="prone" animation_key="reloading, ar2, prone" />	
+    <sound key="fire" fileref="aa-12_shot.wav" pitch_variety="0.05" volume="0.7" />
+    <sound key="magazine_out" fileref="rifle_clip_out.wav" />
+    <sound key="magazine_in" fileref="rifle_clip_in.wav" />
+    <sound key="cycle" fileref="rifle_chamber.wav" />
+    <sound class="impact" fileref="rifle_drop.wav" />
+    <model filename="aa12_frag.xml" />
+
+    <hud_icon filename="hud_aa-12_frag.png" />
+    <commonness value="0.0002" can_respawn_with="0" in_stock="0" />
+    <inventory encumbrance="10.0" price="370.0" />
+	
+    <weak_hand_hold offset="0.2" />
+
+    <projectile file="frag12.projectile" />
+
+   <stance state_key="running" accuracy="0.5" />
+    <stance state_key="walking" accuracy="0.7" />
+    <stance state_key="crouch_moving" accuracy="0.65" />
+    <stance state_key="prone_moving" accuracy="0.5" />
+
+    <stance state_key="standing" accuracy="0.75" />
+    <stance state_key="crouching" accuracy="0.87" />
+    <stance state_key="prone" accuracy="0.95" />
+    <stance state_key="over_wall" accuracy="0.87" />     
+
+    <modifier class="speed" value="-0.10" />       
+</weapon>
+

--- a/weapons/ares_shrike.weapon
+++ b/weapons/ares_shrike.weapon
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<weapon file="base_primary_rare.weapon" key="ares_shrike.weapon">
+    <tag name="machinegun" />
+    <specification 
+  retrigger_time="0.085" 
+  last_burst_retrigger_time="0.4"
+  accuracy_factor="0.9" 
+  sustained_fire_grow_step="0.1" 
+  sustained_fire_diminish_rate="0.4" 
+  magazine_size="60" 
+  can_shoot_standing="0"
+  can_shoot_crouching="1"  
+  suppressed="0" 
+  name="ARES Shrike" 
+  class="4" 
+  burst_shots="6"
+  projectile_speed="100.0" 
+  barrel_offset="0.4" />
+  
+	<next_in_chain key="ares_shrike_s.weapon" share_ammo="1" />
+
+	<!--- Burst fire LMG that helps with trigger discipline -->
+ 	<!--- Lower capacity and lower mobility than the Stoner LMG, also with lower damage --->
+	<!--- Is quite accurate for an LMG -->
+	<!--- Effective RPM is roughly 545 RPM, tying with the Pecheneg, which is the slowest firing LMG -->
+
+    <animation key="recoil" ref="12" />
+    <animation key="recoil" ref="13" />
+    <animation key="recoil" ref="14" />
+    <animation key="reload" ref="35" />
+    <animation state_key="next_in_chain_in" animation_key="switch fire mode" /> 
+
+    <sound key="fire" fileref="ares_shrike_shot.wav" pitch_variety="0.04" volume="0.7" />
+    <sound key="magazine_out" fileref="mg_clip_out.wav" />
+    <sound key="magazine_in" fileref="mg_clip_in.wav" />
+    <sound key="cycle" fileref="rifle_chamber.wav" />
+    <sound class="impact" fileref="rifle_drop.wav" />
+    <model filename="ares_shrike.xml" />
+
+    <hud_icon filename="hud_ares_shrike.png" />
+    <commonness value="0.0003" can_respawn_with="0" in_stock="0" />
+    <inventory encumbrance="10.0" price="300.0" />
+
+    <weak_hand_hold offset="0.2" />
+    <projectile file="bullet.projectile">
+        <result class="hit"  kill_probability="0.57" kill_decay_start_time="0.38" kill_decay_end_time="0.7" />
+    </projectile>
+    
+    <stance state_key="running" accuracy="0.05" />
+    <stance state_key="walking" accuracy="0.4" />
+    <stance state_key="crouch_moving" accuracy="0.1" />
+    <stance state_key="standing" accuracy="0.7" />
+    <stance state_key="crouching" accuracy="0.8" />
+    <stance state_key="prone" accuracy="1.0" /> 
+    <stance state_key="prone_moving" accuracy="0.1" />
+    <stance state_key="over_wall" accuracy="0.9" />     
+    
+    <modifier class="speed" value="-0.07" />
+</weapon>

--- a/weapons/dp28.weapon
+++ b/weapons/dp28.weapon
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<weapon file="base_primary_rare.weapon" key="dp28.weapon">
+    <tag name="machine gun" />
+    <specification 
+  retrigger_time="0.100" 
+  accuracy_factor="0.78" 
+  spread_range="0.25"
+  sustained_fire_grow_step="1.0" 
+  sustained_fire_diminish_rate="2.4" 
+  magazine_size="47" 
+  can_shoot_standing="0"
+  can_shoot_crouching="1" 
+  can_shoot_prone="1"
+  suppressed="0" 
+  name="dp28"
+  stance_accuracy_rate="0.8"  
+  class="0" 
+  projectile_speed="110.0"
+  barrel_offset="0.5" />
+
+	<next_in_chain key="dp28_s.weapon" share_ammo="1" />
+
+    <animation key="recoil" ref="12" />
+    <animation key="recoil" ref="13" />
+    <animation key="recoil" ref="14" />
+    <animation state_key="reload" animation_key="reloading, stoner_lmg" />
+
+    <sound key="fire" fileref="dp28_shot.wav" pitch_variety="0.05" volume="1.0"/>
+    <sound key="magazine_out" fileref="rifle_clip_out.wav" />
+    <sound key="magazine_in" fileref="rifle_clip_in.wav" />
+    <sound key="cycle" fileref="rifle_chamber.wav" />
+    <sound class="impact" fileref="rifle_drop.wav" />    
+    <model filename="dp28.xml" />
+
+    <hud_icon filename="hud_dp28.png" />
+    <commonness value="0.000025" can_respawn_with="0" in_stock="0" />
+    <inventory encumbrance="12.0" price="280.0" />
+
+    <weak_hand_hold offset="0.4" />
+    <projectile file="bullet.projectile">
+        <result class="hit"  kill_probability="0.65" kill_decay_start_time="0.33" kill_decay_end_time="0.64" />
+    </projectile>
+    
+    <stance state_key="running" accuracy="0.1" />
+    <stance state_key="walking" accuracy="0.55" />
+    <stance state_key="crouch_moving" accuracy="0.5" />
+    <stance state_key="prone_moving" accuracy="0.3" />
+
+    <stance state_key="standing" accuracy="0.5" />
+    <stance state_key="crouching" accuracy="0.7" />
+    <stance state_key="prone" accuracy="1.0" />
+
+    <modifier class="speed" value="-0.10" />    
+</weapon>

--- a/weapons/dp28_s.weapon
+++ b/weapons/dp28_s.weapon
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<weapon file="base_primary_rare.weapon" key="dp28_s.weapon">
+    <tag name="machine gun" />
+    <specification 
+  retrigger_time="0.100" 
+  accuracy_factor="0.78" 
+  spread_range="0.20"
+  sustained_fire_grow_step="0.8" 
+  sustained_fire_diminish_rate="2.4" 
+  magazine_size="47" 
+  can_shoot_standing="0"
+  can_shoot_crouching="0" 
+  can_shoot_prone="1"
+  suppressed="0" 
+  name="dp28 - shield" 
+  class="0" 
+  stance_accuracy_rate="1.0"  
+  projectile_speed="110.0"
+  barrel_offset="0.5" />
+
+	<next_in_chain key="dp28.weapon" share_ammo="1" />
+
+    <animation key="recoil" ref="12" />
+    <animation key="recoil" ref="13" />
+    <animation key="recoil" ref="14" />
+    <animation state_key="reload" animation_key="reloading, stoner_lmg" />
+		<animation state_key="next_in_chain_in" animation_key="mount bayonet part 1" />
+		<animation state_key="next_in_chain_out" animation_key="sheath bayonet part 2" />      
+    <animation state_key="running" animation_key="walking" />
+
+    <sound key="fire" fileref="dp28_shot.wav" pitch_variety="0.05" volume="1.0" />
+    <sound key="magazine_out" fileref="rifle_clip_out.wav" />
+    <sound key="magazine_in" fileref="rifle_clip_in.wav" />
+    <sound key="cycle" fileref="rifle_chamber.wav" />
+    <sound class="impact" fileref="rifle_drop.wav" />    
+    <model filename="dp28_s.xml" />
+
+    <hud_icon filename="hud_dp28_s.png" />
+    <commonness value="0.000025" can_respawn_with="0" in_stock="0" />
+    <inventory encumbrance="12.0" price="280.0" />
+
+    <weak_hand_hold offset="0.4" />
+    <projectile file="bullet.projectile">
+        <result class="hit"  kill_probability="0.65" kill_decay_start_time="0.33" kill_decay_end_time="0.64" />
+    </projectile>
+    
+    <stance state_key="running" accuracy="0.1" />
+    <stance state_key="walking" accuracy="0.55" />
+    <stance state_key="crouch_moving" accuracy="0.5" />
+    <stance state_key="prone_moving" accuracy="0.3" />
+
+    <stance state_key="standing" accuracy="0.5" />
+    <stance state_key="crouching" accuracy="0.7" />
+    <stance state_key="prone" accuracy="1.0" />
+
+    <shield offset="-0.7 -0.1 0" extent="0.5 0.8 1.4" usable_for_cover="0"/> 
+
+    <modifier class="speed" value="-0.30" />    
+</weapon>

--- a/weapons/dragons_breath.projectile
+++ b/weapons/dragons_breath.projectile
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="utf-8"?>
+<projectile class="bullet" name="Dragon fire" slot="1" pulldown_in_air="18.0" time_to_live="0.5" key="dragons_flame.projectile">
+	<tag name="flamethrower_flame"/>
+	
+	<trigger class="impact" />
+	<result
+	class="blast"
+	radius="1.2"
+	damage="0.01"
+	push="0"  
+	character_state="death"
+	make_vehicle_hit_sound="0"
+	faction_compare="not_equal"
+	/>
+
+	<rotation class="motion" />
+	
+	<commonness value="0.0" />
+
+
+ 
+    <sound class="result" key="terrain" copy="other" />
+    <sound class="result" key="static_object" copy="other" />
+    <sound class="result" key="character" copy="other" />
+
+
+
+
+
+    <sound class="result" key="terrain" fileref="ricochet1.wav" />
+    <sound class="result" key="terrain" fileref="ricochet2.wav" />
+    <sound class="result" key="terrain" fileref="ricochet3.wav" />
+    <sound class="result" key="terrain" fileref="ricochet4.wav" />
+
+    <sound class="result" key="shield" fileref="ricochet5.wav" />
+    <sound class="result" key="shield" fileref="ricochet6.wav" />
+    <sound class="result" key="shield" fileref="ricochet7.wav" />
+    
+    <sound class="result" key="character" fileref="impact_body2.wav" pitch_variety="0.4" volume="0.7" />
+    <sound class="result" key="character" fileref="impact_body3.wav" pitch_variety="0.4" volume="0.7" />
+    <sound class="result" key="character" fileref="impact_body4.wav" pitch_variety="0.4" volume="0.7" />
+
+    <sound class="result" key="vehicle" copy="terrain" />
+
+    <sound class="result" key="vehicle" tag="metal_thin" file="metal_thin_01.wav" pitch_variety="0.3" volume="0.5" />
+    <sound class="result" key="vehicle" tag="metal_thin" file="metal_thin_02.wav" pitch_variety="0.3" volume="0.5" />
+    <sound class="result" key="vehicle" tag="metal_thin" file="metal_thin_03.wav" pitch_variety="0.3" volume="0.5" />
+    <sound class="result" key="vehicle" tag="metal_thin" file="metal_thin_04.wav" pitch_variety="0.3" volume="0.5" />
+    <sound class="result" key="vehicle" tag="metal_thin" file="metal_thin_05.wav" pitch_variety="0.3" volume="0.5" />  
+    
+    <sound class="result" key="vehicle" tag="deco_car" file="metal_thin_06.wav" pitch_variety="0.3" volume="0.6" />    
+    <sound class="result" key="vehicle" tag="deco_car" file="metal_thin_07.wav" pitch_variety="0.3" volume="0.6" />
+    <sound class="result" key="vehicle" tag="deco_car" file="metal_thin_06.wav" pitch_variety="0.3" volume="0.6" />    
+    <sound class="result" key="vehicle" tag="deco_car" file="metal_thin_07.wav" pitch_variety="0.3" volume="0.8" />    
+    <sound class="result" key="vehicle" tag="deco_car" file="metal_thin_06.wav" pitch_variety="0.3" volume="0.5" />    
+    <sound class="result" key="vehicle" tag="deco_car" file="metal_thin_07.wav" pitch_variety="0.3" volume="0.5" />    
+    <sound class="result" key="vehicle" tag="deco_car" file="metal_thin_08.wav" pitch_variety="0.3" volume="0.7" />
+    <sound class="result" key="vehicle" tag="deco_car" file="metal_thin_08.wav" pitch_variety="0.3" volume="0.8" />
+
+    <sound class="result" key="vehicle" tag="metal_heavy" file="metal_heavy_01.wav" pitch_variety="0.3" volume="0.5" />
+    <sound class="result" key="vehicle" tag="metal_heavy" file="metal_heavy_02.wav" pitch_variety="0.3" volume="0.5" /> 
+    <sound class="result" key="vehicle" tag="metal_heavy" file="metal_heavy_03.wav" pitch_variety="0.3" volume="0.5" />       
+    
+    <sound class="result" key="vehicle" tag="sandbag" file="barrier_bullet_01.wav" pitch_variety="0.3" volume="0.8" />  
+    <sound class="result" key="vehicle" tag="sandbag" file="barrier_bullet_02.wav" pitch_variety="0.3" volume="0.8" /> 
+    <sound class="result" key="vehicle" tag="sandbag" file="barrier_bullet_03.wav" pitch_variety="0.3" volume="0.4" /> 
+    
+    <sound class="result" key="vehicle" tag="metal_dumpster" file="dumpster_bullet_01.wav" pitch_variety="0.4" volume="0.6" />  
+    <sound class="result" key="vehicle" tag="metal_dumpster" file="dumpster_bullet_01.wav" pitch_variety="0.4" volume="0.5" />    
+    <sound class="result" key="vehicle" tag="metal_dumpster" file="dumpster_bullet_02.wav" pitch_variety="0.4" volume="0.8" />              
+
+    <sound class="result" key="static_object" copy="terrain" />
+
+
+
+
+
+	<!-- <effect class="activated" ref="SmokePropulsion" /> -->
+	<effect class="activated" ref="DragonPropulsion" lighting="0" />   
+	<effect class="activated" ref="FlameSparkle" lighting="0" /> 
+
+	<!-- <effect class="result" ref="SmokePropulsionEnd" /> -->
+	<effect class="result" key="terrain" ref="FlamePropulsionEnd" lighting="0" /> 
+	<effect class="result" key="terrain" ref="FlameSparkleEnd" lighting="0" />
+	<effect class="result" key="terrain" ref="DragonSparkle" lighting="0" />
+	<effect class="result" key="terrain" ref="DragonFlame2" lighting="0" />    
+   
+
+	<!-- <effect class="result" type="splat_map" surface_tag="" size="3.0" atlas_index="0" layer="1" /> -->
+	<effect class="result" type="splat_map" surface_tag="" size="2.0" atlas_index="4" layer="0" />
+
+    
+    <effect class="result" key="other" copy="terrain" />
+    <effect class="result" key="vehicle" copy="terrain" />
+    <effect class="result" key="static_object" copy="terrain" />    
+    
+    <effect class="result" key="shield" ref="ShieldBurst" />   
+
+
+
+
+	<trail probability="1.0" key="DragonTrail" />
+
+</projectile>

--- a/weapons/dragons_breath.weapon
+++ b/weapons/dragons_breath.weapon
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<weapon file="base_primary.weapon" key="dragons_breath.weapon" time_to_live_out_in_the_open="90.0" drop_count_factor_on_death="1.0" player_death_drop_owner_lock_time="45.0">
+    <tag name="cqb" />
+    <specification 
+  retrigger_time="0.21" 
+  accuracy_factor="0.68" 
+  sustained_fire_grow_step="2.0" 
+  sustained_fire_diminish_rate="0.9" 
+  magazine_size="2" 
+  can_shoot_standing="1" 
+  suppressed="0" 
+  carry_in_two_hands="0" 
+  name="Dragons breath" 
+  class="4" 
+  burst_shots="1"
+  reload_one_at_a_time="0" 
+  sight_range_modifier="1.0" 
+  projectile_speed="80.0" 
+  projectiles_per_shot="18" />
+
+	<animation state_key="recoil"	animation_key="recoil, pistol" />
+    <animation state_key="reload"	animation_key="reloading, sawn off shotgun" />
+	<animation state_key="hold"	animation_key="hold, pistol" />
+	<animation state_key="hold_casual"	animation_key="hold_casual, pistol" />
+	<animation state_key="hold_on_wall"	animation_key="hold, pistol" />
+	<animation state_key="still_against_wall"	animation_key="hold, pistol" />
+	<animation state_key="crouching"	animation_key="crouch, pistol" />
+	<animation state_key="running"	animation_key="running, pistol" />
+	<animation state_key="walking"	animation_key="walking, pistol" />
+    <animation state_key="changing_weapon_in" 	animation_key="change weapon in, single hand carry" />
+    <animation state_key="prone_still" animation_key="prone_still, pistol" />
+    <animation state_key="walking_backwards" animation_key="walking backwards, pistol" />
+	
+    <sound key="fire" fileref="sawn-off_shotgun_shot.wav" />
+    <sound key="magazine_out" fileref="revolver_cycle_in.wav" />
+    <sound key="magazine_in" fileref="revolver_magazine_out.wav" volume="1" />    
+    <sound key="cycle" fileref="revolver_magazine_in.wav" volume="1" />
+    <model filename="dragon_saw.xml" />
+
+    <hud_icon filename="hud_dragons_breath.png" />
+    <commonness value="0.0001" can_respawn_with="0" in_stock="0" />
+    <inventory encumbrance="5.0" price="360.0" />
+
+    <capacity value="0" source="rank" source_value="0.0" />
+    <capacity value="1" source="rank" source_value="0.4" />
+
+    <weak_hand_hold offset="0.2" />
+    <projectile file="dragons_breath.projectile" />
+    
+    <modifier class="speed" value="-0.02" />
+</weapon>

--- a/weapons/enforcer.weapon
+++ b/weapons/enforcer.weapon
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<weapon file="base_primary_sniper.weapon" key="enforcer.weapon" time_to_live_out_in_the_open="90.0" drop_count_factor_on_death="1.0" player_death_drop_owner_lock_time="45.0">
+    <tag name="sniper" />
+    <specification 
+  retrigger_time="-0.667" 
+  accuracy_factor="1.0" 
+  sustained_fire_grow_step="2.5" 
+  sustained_fire_diminish_rate="0.9" 
+  magazine_size="8" 
+  can_shoot_standing="1" 
+  suppressed="0" 
+  name="M711-LA Enforcer" 
+  class="2" 
+  reload_one_at_a_time="1" 
+  sight_range_modifier="1.3" 
+  projectile_speed="130.0" 
+  barrel_offset="0.4"
+  projectiles_per_shot="1" />
+
+    <animation state_key="recoil" ref="27" />
+	<animation key="recoil" stance_key="prone" animation_key="recoil1, big, prone" />
+    <animation state_key="cycle" animation_key="cycle, enforcer" />
+	<animation key="cycle" stance_key="prone" animation_key="bolt cycle, prone" />	
+    <animation state_key="reload" ref="29" />
+	<animation key="reload" stance_key="prone" animation_key="reloading, pump action, prone" />	
+    <sound key="fire" fileref="enforcer_fire.wav" volume="0.7" />
+    <sound key="cycle" fileref="mossberg500_cycle.wav" />
+    <sound key="reload_one" fileref="mossberg500_reload.wav" />
+    <sound class="impact" fileref="rifle_drop.wav" />
+    <model filename="enforcer.xml" />
+
+    <hud_icon filename="hud_enforcer.png" />
+    <commonness value="0.0001" can_respawn_with="0" in_stock="0" />
+    
+    <capacity value="0" source="rank" source_value="0.0" />
+    <capacity value="1" source="rank" source_value="0.3" />
+    
+    <inventory encumbrance="10.0" price="330.0" />
+
+    <weak_hand_hold offset="0.3" />
+    <projectile file="bullet.projectile">
+        <result class="hit" kill_probability="1.2" kill_decay_start_time="0.39" kill_decay_end_time="0.62" />
+    </projectile>
+	
+
+    <modifier class="speed" value="-0.08" />
+</weapon>

--- a/weapons/fal.weapon
+++ b/weapons/fal.weapon
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<weapon file="base_primary_rare.weapon" key="fal.weapon">
+    <tag name="assault" />
+    <specification 
+    retrigger_time="0.113" 
+    accuracy_factor="1.0" 
+    sustained_fire_grow_step="0.4" 
+    sustained_fire_diminish_rate="1.1" 
+    magazine_size="20" 
+    can_shoot_standing="1" 
+    suppressed="0" 
+    name="FN FAL" 
+    class="0" 
+    projectile_speed="100.0"
+    barrel_offset="0.6"
+    />
+    
+	<next_in_chain key="fal_bayonet.weapon" share_ammo="1" />  
+
+	<stance state_key="standing" accuracy="0.865" />
+	<stance state_key="crouching" accuracy="0.91" />  
+
+    <animation key="recoil" ref="12" />
+    <animation key="recoil" ref="13" />
+    <animation key="recoil" ref="14" />
+    <animation state_key="reload" animation_key="reloading, aks74u" />
+	<animation key="reload" stance_key="prone" animation_key="reloading, ar1, prone" />	
+	
+		<animation state_key="next_in_chain_in" animation_key="sheath bayonet part 2" />
+		<animation state_key="next_in_chain_out" animation_key="mount bayonet part 1" />     
+
+<!--    <animation state_key="stabbing" animation_key="melee, bayonet" />     -->
+
+    <animation state_key="celebrate_shoot" animation_key="celebrating, shooting" />
+
+    <sound key="fire" fileref="fal_shot.wav" pitch_variety="0.05" volume="0.5" />
+    <sound key="magazine_out" fileref="rifle_clip_out.wav" />
+    <sound key="magazine_in" fileref="rifle_clip_in.wav" />
+    <sound key="cycle" fileref="rifle_chamber.wav" />
+<!--    <sound key="stab" fileref="grenade_throw1.wav" pitch_variety="0.05" volume="0.5"/>   -->
+    <sound class="impact" fileref="rifle_drop.wav" />
+    <model filename="fal.xml" />
+
+    <hud_icon filename="hud_fal.png" />
+    <commonness value="0.0002" can_respawn_with="0" in_stock="0" />
+    <capacity value="0" source="rank" source_value="0.0" />
+    <capacity value="1" source="rank" source_value="0.55" />        
+    <inventory encumbrance="10.0" price="420.0" />
+
+   <projectile file="bullet.projectile">
+        <result class="hit" kill_probability="0.58" kill_decay_start_time="0.42" kill_decay_end_time="0.75" />
+    </projectile>
+	<modifier class="speed" value="-0.036" />
+
+</weapon>

--- a/weapons/fal_bayonet.weapon
+++ b/weapons/fal_bayonet.weapon
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<weapon file="base_primary_rare.weapon" key="fal_bayonet.weapon">
+    <tag name="assault" />
+    <specification 
+    retrigger_time="0.113" 
+    accuracy_factor="1.0" 
+    sustained_fire_grow_step="0.4" 
+    sustained_fire_diminish_rate="1.1" 
+    magazine_size="20" 
+    can_shoot_standing="1" 
+    suppressed="0" 
+    name="FN FAL - bayonet" 
+    class="0" 
+    projectile_speed="100.0"
+    barrel_offset="0.6"
+    stab_enabled="1"
+    stab_range="3.0"
+    />
+
+	<next_in_chain key="fal.weapon" share_ammo="1" />
+
+	<stance state_key="standing" accuracy="0.84" />
+	<stance state_key="crouching" accuracy="0.88" />
+
+    <animation key="recoil" ref="12" />
+    <animation key="recoil" ref="13" />
+    <animation key="recoil" ref="14" />
+    <animation state_key="reload" animation_key="reloading, aks74u" />
+	<animation key="reload" stance_key="prone" animation_key="reloading, ar1, prone" />	
+	
+		<animation state_key="next_in_chain_in" animation_key="mount bayonet part 2" />
+		<animation state_key="next_in_chain_out" animation_key="sheath bayonet part 1" />      
+
+    <animation state_key="stabbing" animation_key="melee, bayonet" />
+
+    <animation state_key="celebrate_shoot" animation_key="celebrating, shooting" />
+
+    <sound key="fire" fileref="fal_shot.wav" pitch_variety="0.05" volume="0.5" />
+    <sound key="magazine_out" fileref="rifle_clip_out.wav" />
+    <sound key="magazine_in" fileref="rifle_clip_in.wav" />
+    <sound key="cycle" fileref="rifle_chamber.wav" />
+    <sound key="stab" fileref="grenade_throw1.wav" pitch_variety="0.05" volume="0.5"/>
+    <sound class="impact" fileref="rifle_drop.wav" />
+    <model filename="fal_bayonet.xml" />
+
+    <hud_icon filename="hud_fal_bayonet.png" />
+    <commonness value="0.0002" can_respawn_with="0" in_stock="0" />
+    <capacity value="0" source="rank" source_value="0.0" />
+    <capacity value="1" source="rank" source_value="0.55" />        
+    <inventory encumbrance="10.0" price="420.0" />
+
+   <projectile file="bullet.projectile">
+        <result class="hit" kill_probability="0.58" kill_decay_start_time="0.42" kill_decay_end_time="0.75" />
+    </projectile>
+	<modifier class="speed" value="-0.036" />
+
+</weapon>

--- a/weapons/fd338.weapon
+++ b/weapons/fd338.weapon
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<weapon file="base_primary_rare.weapon" key="fd338.weapon">
+    <tag name="sniper" />
+    <specification 
+	retrigger_time="0.3" 
+	accuracy_factor="1.0" 
+	sustained_fire_grow_step="2.4" 
+	sustained_fire_diminish_rate="1.1" 
+	magazine_size="10" 
+	can_shoot_standing="1" 
+	suppressed="0" 
+	name="FD-338" 
+	class="4" 
+	burst_shots="1"
+	reload_one_at_a_time="0" 
+	sight_range_modifier="1.55" 
+	projectile_speed="180.0" 
+    stance_accuracy_rate="1.0"  
+	barrel_offset="0.5" 
+	projectiles_per_shot="1" />
+
+	<next_in_chain key="fd338sd.weapon" share_ammo="1" />   
+
+    <animation key="recoil" ref="27" />
+    <animation key="cycle" ref="30" />
+    <animation key="reload" ref="35" />
+	<animation key="reload" stance_key="prone" animation_key="reloading, ar1, prone" />	
+	
+    <sound key="fire" fileref="fd338_shot.wav" pitch_variety="0.05" volume="1.0"/>
+    <sound key="cycle" fileref="sniper_cycle.wav" />
+    <sound key="magazine_out" fileref="sniper_clip_out.wav" />
+    <sound key="magazine_in" fileref="sniper_clip_in.wav" />
+    <sound key="cycle_out" fileref="sniper_cycle_out.wav" />
+    <sound key="cycle_in" fileref="sniper_cycle_in.wav" />
+    <sound class="impact" fileref="rifle_drop.wav" />
+
+    <model filename="fd338.xml" />
+    <hud_icon filename="hud_fd338.png" />
+    <commonness value="0.0002" can_respawn_with="0" in_stock="0" />
+    <inventory encumbrance="10.0" price="338" />
+  
+    <weak_hand_hold offset="0.3" />
+
+    <projectile file="bullet.projectile">
+        <result 
+		class="hit" 
+		kill_probability="0.9" 
+		kill_decay_start_time="0.52" 
+		kill_decay_end_time="0.82" />
+    </projectile>
+    
+    <stance state_key="running" accuracy="0.1" />
+    <stance state_key="walking" accuracy="0.3" />
+    <stance state_key="crouch_moving" accuracy="0.1" />
+    <stance state_key="standing" accuracy="0.65" />
+    <stance state_key="crouching" accuracy="0.9" />
+    <stance state_key="prone" accuracy="1.0" /> 
+    <stance state_key="prone_moving" accuracy="0.1" />
+    <stance state_key="over_wall" accuracy="0.93" />
+    
+    <modifier class="speed" value="-0.10" />    
+
+</weapon>

--- a/weapons/fd338sd.weapon
+++ b/weapons/fd338sd.weapon
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="utf-8"?>
+<weapon file="base_primary_rare.weapon" key="fd338sd.weapon">
+    <tag name="sniper" />
+    <specification 
+	retrigger_time="0.4" 
+	accuracy_factor="0.95" 
+	sustained_fire_grow_step="2.2" 
+	sustained_fire_diminish_rate="1.1" 
+	magazine_size="10" 
+	can_shoot_standing="1" 
+	suppressed="1" 
+	name="FD-338SD" 
+	class="4" 
+	burst_shots="1"
+	reload_one_at_a_time="0" 
+	sight_range_modifier="1.55" 
+	projectile_speed="150.0" 
+    stance_accuracy_rate="1.0"  
+	barrel_offset="0.5" 
+	projectiles_per_shot="1" />
+
+	<next_in_chain key="fd338.weapon" share_ammo="1" />   
+
+    <animation state_key="next_in_chain_in" animation_key="mount suppressor, fd338" />
+	<animation state_key="next_in_chain_out" animation_key="demount suppressor, fd338" />
+
+    <animation key="recoil" ref="27" />
+    <animation key="cycle" ref="30" />
+    <animation key="reload" ref="35" />
+	<animation key="reload" stance_key="prone" animation_key="reloading, ar1, prone" />	
+	
+    <sound key="fire" fileref="fd338sd_shot.wav"    pitch_variety="0.05" volume="0.4"/>
+    <sound key="cycle" fileref="sniper_cycle.wav" />
+    <sound key="magazine_out" fileref="sniper_clip_out.wav" />
+    <sound key="magazine_in" fileref="sniper_clip_in.wav" />
+    <sound key="cycle_out" fileref="sniper_cycle_out.wav" />
+    <sound key="cycle_in" fileref="sniper_cycle_in.wav" />
+    <sound class="impact" fileref="rifle_drop.wav" />
+
+    <model filename="fd338sd.xml" />
+    <hud_icon filename="hud_fd338sd.png" />
+    <commonness value="0.000001" can_respawn_with="0" in_stock="0" />
+    <inventory encumbrance="10.0" price="338" />
+
+    <weak_hand_hold offset="0.3" />
+
+    <projectile file="bullet.projectile">
+        <result 
+		class="hit" 
+		kill_probability="0.8" 
+		kill_decay_start_time="0.45" 
+		kill_decay_end_time="0.75" />
+    </projectile>
+    
+    <stance state_key="running" accuracy="0.1" />
+    <stance state_key="walking" accuracy="0.3" />
+    <stance state_key="crouch_moving" accuracy="0.1" />
+    <stance state_key="standing" accuracy="0.7" />
+    <stance state_key="crouching" accuracy="0.9" />
+    <stance state_key="prone" accuracy="1.0" /> 
+    <stance state_key="prone_moving" accuracy="0.1" />
+    <stance state_key="over_wall" accuracy="0.93" />
+    
+    <modifier class="speed" value="-0.10" />    
+
+</weapon>

--- a/weapons/flamethrower.weapon
+++ b/weapons/flamethrower.weapon
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="utf-8"?>
+<weapon key="flamethrower.weapon" on_ground_up="0 0 1" time_to_live_out_in_the_open="90.0" drop_count_factor_on_death="1" player_death_drop_owner_lock_time="45.0" >
+	<tag name="cqb" />
+	
+	<specification
+	retrigger_time="0.05"
+	projectiles_per_shot="1"
+	spread_range="0.025"
+	accuracy_factor="1.5"
+	sustained_fire_grow_step="0.1"
+	sustained_fire_diminish_rate="1.0"
+	magazine_size="100"
+	suppressed="1"
+	can_shoot_prone="0"
+	name="flamethrower"
+	class="0"
+	barrel_offset="0.35"
+	barrel_offset_3d="0 -0.1 0.35"
+	projectile_speed="140.0"
+	/>
+
+	<addon_model filename="backpack_fuel.xml" />
+	
+	<animation key="recoil" ref="12" />
+	<animation key="recoil" ref="13" />
+	<animation key="recoil" ref="14" />
+	<animation state_key="reload" animation_key="reloading, flamethrower" />
+	
+	<sound key="fire" fileref="flamethrower.wav" volume="2.4"/>
+	<sound key="magazine_out" fileref="flamer_out.wav" />
+	<sound key="magazine_in" fileref="portable_mortar_reload.wav" />
+    <sound key="cycle" fileref="musket_magazine_out.wav" volume="0.25" />
+	
+	<model filename="flamer.xml" />
+	<hud_icon filename="hud_flamethrower.png" />
+	
+	<commonness value="0.0005" can_respawn_with="0" in_stock="0" />
+	<inventory encumbrance="10.0" price="400.0" />
+	
+	<capacity value="1" source="rank" source_value="0.6" />
+	
+	<ballistics
+	near_far_distance="100.0"
+	speed_estimation_near="25.0"
+	speed_estimation_far="25.0"
+	max_speed="25.0" 
+	randomness="0.05"
+	/> 
+	<!-- speed 30 is too much range, 20 is not enough, 25 should be fine -->
+	<projectile file="flamethrower_flame.projectile"/>
+	
+	<stance state_key="running" accuracy="1.0" />
+	<stance state_key="walking" accuracy="1.0" />
+	<stance state_key="crouch_moving" accuracy="1.0" />
+	<stance state_key="prone_moving" accuracy="1.0" />
+	
+	<stance state_key="standing" accuracy="1.0" />
+	<stance state_key="crouching" accuracy="1.0" />
+	<stance state_key="prone" accuracy="1.0" />
+	
+	<modifier class="speed" value="-0.15" />
+
+
+</weapon>
+
+

--- a/weapons/flamethrower_flame.projectile
+++ b/weapons/flamethrower_flame.projectile
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<projectile class="grenade" name="flamethrower" slot="1" pulldown_in_air="25.0" time_to_live="0.02" key="flamethrower_flame.projectile">
+	<tag name="flamethrower_flame"/>
+	
+	<trigger class="impact" />
+	<result
+	class="blast"
+	radius="1.5"
+	damage="0.02"
+	push="0"  
+	character_state="death"
+	make_vehicle_hit_sound="0"
+	faction_compare="not_equal"
+	/>
+
+	<rotation class="motion" />
+	
+	<commonness value="0.0" />
+
+    <sound class="result" key="other" fileref="burn.wav" volume="0.7" />
+    <sound class="result" key="vehicle" fileref="burn.wav" volume="0.7" />
+ 
+    <sound class="result" key="terrain" copy="other" />
+    <sound class="result" key="static_object" copy="other" />
+    <sound class="result" key="character" copy="other" />
+
+	<effect class="activated" ref="SmokePropulsion" />
+	<effect class="activated" ref="FlamePropulsion" lighting="0" />
+	<effect class="activated" ref="FlameSparkle" lighting="0" />
+
+	<effect class="result" ref="SmokePropulsionEnd" />
+	<effect class="result" ref="FlamePropulsionEnd" lighting="0" />
+	<effect class="result" ref="FlameSparkleEnd" lighting="0" />
+	
+	<effect class="result" key="terrain" ref="BurnOut_short" post_processing="1" /> 
+
+	<!-- <effect class="result" type="splat_map" surface_tag="" size="3.0" atlas_index="0" layer="1" /> -->
+	<effect class="result" type="splat_map" surface_tag="" size="2.0" atlas_index="4" layer="0" />
+
+	<trail probability="1.0" key="FlamethrowerTrail" />
+
+</projectile>

--- a/weapons/frag12.projectile
+++ b/weapons/frag12.projectile
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<projectile class="bullet" name="Frag-12" slot="1" time_to_live="1.0" radius="2.0" pulldown_in_air="4.0">
+    <result class="blast" radius="1.8" damage="0.08" decal="0" faction_compare="not_equal"/>
+    <trigger class="impact" />
+    <rotation class="motion" />
+
+    <sound class="result" key="other" fileref="explosion5.wav" volume="0.6" />
+
+    <sound class="result" key="terrain" copy="other" />
+    <sound class="result" key="static_object" copy="other" />
+    <sound class="result" key="vehicle" copy="other" />
+    <sound class="result" key="character" copy="other" />
+
+   	<effect class="result" key="vehicle" ref="HitTank" lighting="1" />
+   	<effect class="result" key="vehicle" ref="HitTankSparks" />
+    <effect class="result" key="vehicle" ref="SmokeBurstSmall" post_processing="1" />  
+    <effect class="result" key="vehicle" ref="BurstShineSmall" lighting="0" />
+    <effect class="result" key="vehicle" ref="Godray" lighting="0" />
+
+<!--    <effect class="result" key="terrain" ref="BigBurst" use_surface_color="1" />   
+    <effect class="result" key="terrain" ref="SmokeTop" post_processing="1" />  -->
+    <effect class="result" key="terrain" ref="SmokeBurstSmall" post_processing="1" />  
+    <effect class="result" key="terrain" ref="BurstShineSmall" lighting="0" />
+
+<!--    <effect class="result" key="terrain" ref="ShadowSmoke" shadow="1" /> -->
+    <effect class="result" type="splat_map" surface_tag="" size="2.0" atlas_index="0" layer="1" />
+    <effect class="result" type="splat_map" surface_tag="" size="4.0" atlas_index="4" layer="0" />
+    <effect class="result" type="splat_map" surface_tag="" size="5.0" atlas_index="0" layer="2" additive="0" /> <!-- remove top snow everywhere -->
+
+<!--    <effect class="result" key="other" ref="SmokeTop" post_processing="1" /> -->
+    <effect class="result" key="other" ref="SmokeBurstSmall" post_processing="1" />       
+    <effect class="result" key="other" ref="BurstShineSmall" lighting="0" /> 
+
+<!--     <effect class="result" key="other" ref="ShadowSmoke" shadow="1" />  -->
+
+    <effect class="result" key="static_object" copy="terrain" />
+    <effect class="result" key="character" copy="terrain" />  
+	
+    <trail probability="1.0" />
+
+</projectile>

--- a/weapons/g11.weapon
+++ b/weapons/g11.weapon
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<weapon file="base_primary_rare.weapon" key="g11.weapon">
+    <tag name="assault" />
+    <specification 
+  retrigger_time="0.13" 
+  accuracy_factor="1.0" 
+  sustained_fire_grow_step="0.3" 
+  sustained_fire_diminish_rate="1.4" 
+  sight_range_modifier="1.2"
+  magazine_size="45" 
+  can_shoot_standing="1" 
+  suppressed="0" 
+  name="G11" 
+  class="0" 
+  projectile_speed="100.0" 
+  barrel_offset="0.3" />
+  
+	<next_in_chain key="g11_alt.weapon" share_ammo="1"/>  
+  
+
+    <animation key="recoil" ref="12" />
+    <animation key="recoil" ref="13" />
+    <animation key="recoil" ref="14" />
+    <animation state_key="reload" animation_key="reloading, mp5sd" />
+	<animation key="reload" stance_key="prone" animation_key="reloading, ar1, prone" />	
+	<animation state_key="next_in_chain_in" animation_key="switch fire mode" />
+	
+
+    <sound key="fire" fileref="g11_shot.wav" volume="0.4" pitch_variety="0.04" />
+    <sound key="magazine_out" fileref="rifle_clip_out.wav" />
+    <sound key="magazine_in" fileref="rifle_clip_in.wav" />
+    <sound key="cycle" fileref="rifle_chamber.wav" />
+    <sound class="impact" fileref="rifle_drop.wav" />    
+    <model filename="g11.xml" />
+
+    <hud_icon filename="hud_g11.png" />
+    <commonness value="0.000025" can_respawn_with="0" in_stock="0" />
+    
+    <capacity source="rank" source_value="0.0" value="0" />
+    <capacity source="rank" source_value="1.0" value="1" />    
+    
+    <inventory encumbrance="10" price="440.0" />
+
+    <weak_hand_hold offset="0.2" />
+    <projectile file="bullet.projectile">
+        <result class="hit"  kill_probability="0.53" kill_decay_start_time="0.40" kill_decay_end_time="0.64" />
+    </projectile>
+
+    
+    <modifier class="speed" value="-0.02" />
+</weapon>

--- a/weapons/g11_alt.weapon
+++ b/weapons/g11_alt.weapon
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<weapon file="base_primary_rare.weapon" key="g11_alt.weapon">
+    <tag name="assault" />
+    <specification 
+  retrigger_time="0.02" 
+  last_burst_retrigger_time="0.45"  
+  accuracy_factor="1.0" 
+  sustained_fire_grow_step="0.10" 
+  sustained_fire_diminish_rate="0.4" 
+  sight_range_modifier="1.2"
+  magazine_size="45" 
+  can_shoot_standing="1" 
+  suppressed="0" 
+  name="G11 - burst" 
+  class="4" 
+  projectile_speed="100.0" 
+  barrel_offset="0.3" 
+  burst_shots="3"/>
+  
+	<next_in_chain key="g11.weapon" share_ammo="1"/>  
+
+    <animation key="recoil" ref="12" />
+    <animation key="recoil" ref="13" />
+    <animation key="recoil" ref="14" />
+    <animation state_key="reload" animation_key="reloading, mp5sd" />
+	<animation key="reload" stance_key="prone" animation_key="reloading, ar1, prone" />	
+    <animation state_key="next_in_chain_in" animation_key="switch fire mode" />
+	
+
+    <sound key="fire" fileref="g11_shot.wav" volume="0.4" pitch_variety="0.04" />
+    <sound key="magazine_out" fileref="rifle_clip_out.wav" />
+    <sound key="magazine_in" fileref="rifle_clip_in.wav" />
+    <sound key="cycle" fileref="rifle_chamber.wav" />
+    <sound class="impact" fileref="rifle_drop.wav" />    
+    <model filename="g11.xml" />
+
+    <hud_icon filename="hud_g11_alt.png" />
+    <commonness value="0.000025" can_respawn_with="0" in_stock="0" />
+    
+    <capacity source="rank" source_value="0.0" value="0" />
+    <capacity source="rank" source_value="1.0" value="1" />    
+    
+    <inventory encumbrance="10" price="440.0" />
+
+    <weak_hand_hold offset="0.2" />
+    <projectile file="bullet.projectile">
+        <result class="hit"  kill_probability="0.53" kill_decay_start_time="0.40" kill_decay_end_time="0.64" />
+    </projectile>
+
+    
+    <modifier class="speed" value="-0.02" />
+</weapon>

--- a/weapons/g3_1x.weapon
+++ b/weapons/g3_1x.weapon
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<weapon file="base_primary_rare.weapon" key="g3_1x.weapon">
+    <tag name="assault" />
+    <specification 
+    retrigger_time="0.12" 
+    accuracy_factor="1.0" 
+    sustained_fire_grow_step="0.5" 
+    sustained_fire_diminish_rate="1.8" 
+    magazine_size="20" 
+    can_shoot_standing="1" 
+    suppressed="0" 
+    name="G3A3" 
+    class="0" 
+    projectile_speed="115.0"
+    barrel_offset="0.6"
+    />
+    
+	<next_in_chain key="g3_3x.weapon" share_ammo="1" />  
+
+    <animation state_key="next_in_chain_in" animation_key="switch fire mode" />    
+
+    <animation key="recoil" ref="12" />
+    <animation key="recoil" ref="13" />
+    <animation key="recoil" ref="14" />
+    <animation state_key="reload" animation_key="reloading, aks74u" />
+
+    <animation state_key="celebrate_shoot" animation_key="celebrating, shooting" />
+
+    <sound key="fire" fileref="g3_shot.wav" pitch_variety="0.05" volume="1.0" />
+    <sound key="magazine_out" fileref="rifle_clip_out.wav" />
+    <sound key="magazine_in" fileref="rifle_clip_in.wav" />
+    <sound key="cycle" fileref="rifle_chamber.wav" />
+    <sound class="impact" fileref="rifle_drop.wav" />
+    <model filename="g3_1x.xml" />
+
+    <hud_icon filename="hud_g3_1x.png" />
+    <commonness value="0.0001" can_respawn_with="0" in_stock="0" />     
+    <inventory encumbrance="10.0" price="490.0" />
+
+   <projectile file="bullet.projectile">
+        <result class="hit" kill_probability="0.6" kill_decay_start_time="0.35" kill_decay_end_time="0.78" />
+    </projectile>
+
+	<modifier class="speed" value="-0.04" />
+
+</weapon>

--- a/weapons/g3_3x.weapon
+++ b/weapons/g3_3x.weapon
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<weapon file="base_primary_rare.weapon" key="g3_3x.weapon">
+    <tag name="assault" />
+    <specification 
+    retrigger_time="0.2" 
+    accuracy_factor="1.0" 
+    sustained_fire_grow_step="0.6" 
+    sustained_fire_diminish_rate="1.8" 
+    magazine_size="20" 
+    can_shoot_standing="1" 
+    suppressed="0" 
+    name="G3A3 - scoped" 
+    class="4" 
+    burst_shots="1"
+    sight_range_modifier="1.35" 
+    projectile_speed="115.0"
+    barrel_offset="0.6"
+    />
+    
+	<next_in_chain key="g3_1x.weapon" share_ammo="1" />  
+    <animation state_key="next_in_chain_in" animation_key="switch fire mode" />    
+
+    <animation key="recoil" ref="12" />
+    <animation key="recoil" ref="13" />
+    <animation key="recoil" ref="14" />
+    <animation state_key="reload" animation_key="reloading, aks74u" />
+
+    <animation state_key="celebrate_shoot" animation_key="celebrating, shooting" />
+
+    <sound key="fire" fileref="g3_shot.wav" pitch_variety="0.05" volume="1.0" />
+    <sound key="magazine_out" fileref="rifle_clip_out.wav" />
+    <sound key="magazine_in" fileref="rifle_clip_in.wav" />
+    <sound key="cycle" fileref="rifle_chamber.wav" />
+    <sound class="impact" fileref="rifle_drop.wav" />
+    <model filename="g3_3x.xml" />
+
+    <hud_icon filename="hud_g3_3x.png" />
+    <commonness value="0.0001" can_respawn_with="0" in_stock="0" />
+      
+    <inventory encumbrance="10.0" price="490.0" />
+
+   <projectile file="bullet.projectile">
+        <result class="hit" kill_probability="0.6" kill_decay_start_time="0.35" kill_decay_end_time="0.78" />
+    </projectile>
+
+	<modifier class="speed" value="-0.04" />
+
+</weapon>

--- a/weapons/honey_badger.weapon
+++ b/weapons/honey_badger.weapon
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<weapon file="base_primary_rare.weapon" key="honey_badger.weapon">
+    <tag name="assault" />
+    <specification 
+  retrigger_time="0.075" 
+	last_burst_retrigger_time="0.35"  
+  accuracy_factor="1.0" 
+  sustained_fire_grow_step="0.38" 
+  sustained_fire_diminish_rate="1.30" 
+  magazine_size="30" 
+  can_shoot_standing="1" 
+  suppressed="1" 
+  name="AAC Honey Badger" 
+  class="4" 
+  projectile_speed="105.0" 
+  barrel_offset="0.4" 
+  burst_shots="3"/>
+
+    <animation key="recoil" ref="12" />
+    <animation key="recoil" ref="13" />
+    <animation key="recoil" ref="14" />
+    <animation state_key="reload" animation_key="reloading, mp5sd" />
+	<animation key="reload" stance_key="prone" animation_key="reloading, ar1, prone" />	
+
+    <sound key="fire" fileref="honey_badger_shot.wav" volume="0.4" pitch_variety="0.04" />
+    <sound key="magazine_out" fileref="rifle_clip_out.wav" />
+    <sound key="magazine_in" fileref="rifle_clip_in.wav" />
+    <sound key="cycle" fileref="rifle_chamber.wav" />
+    <sound class="impact" fileref="rifle_drop.wav" />    
+    <model filename="honey_badger.xml" />
+
+    <hud_icon filename="hud_honeybadger.png" />
+    <commonness value="0.00003" can_respawn_with="0" in_stock="0"/>
+    
+    <capacity source="rank" source_value="0.0" value="0" />
+    <capacity source="rank" source_value="1.0" value="1" />    
+    
+    <inventory encumbrance="10.0" price="390.0" />
+
+    <weak_hand_hold offset="0.2" />
+    <projectile file="bullet.projectile">
+        <result class="hit"  kill_probability="0.45" kill_decay_start_time="0.34" kill_decay_end_time="0.52" />
+    </projectile>
+
+    
+    <modifier class="speed" value="-0.02" />
+</weapon>

--- a/weapons/invasion_all_weapons.xml
+++ b/weapons/invasion_all_weapons.xml
@@ -502,13 +502,13 @@
   </weapon>
 
   <weapon file="flamethrower.weapon">
-    <commonness value="0.0" in_stock="0" />
+    <commonness value="0.0005" in_stock="0" />
     <capacity source="rank" source_value="0.0" value="0" />
     <capacity source="rank" source_value="0.6" value="1" />
   </weapon>
 
   <weapon file="aa12_frag.weapon">
-    <commonness value="0.0" in_stock="0" />
+    <commonness value="0.0002" in_stock="0" />
     <capacity source="rank" source_value="0.0" value="0" />
     <capacity source="rank" source_value="0.3" value="1" />
   </weapon>
@@ -568,7 +568,7 @@
    <weapon file="medikit_ai.weapon" />
    <weapon file="medikit_ai_2.weapon" />
    <weapon file="dragons_breath.weapon" >
-    <commonness value="0.0" in_stock="0" />
+    <commonness value="0.0001" in_stock="0" />
     <capacity source="rank" source_value="0.0" value="0" />
     <capacity source="rank" source_value="0.4" value="1" />
    </weapon>

--- a/weapons/invasion_all_weapons.xml
+++ b/weapons/invasion_all_weapons.xml
@@ -428,13 +428,13 @@
   <weapon file="mortar_vulcan.weapon" />
 
   <weapon file="honey_badger.weapon">
-    <commonness value="0.0" in_stock="0" />
+    <commonness value="0.00003" in_stock="0" />
     <capacity source="rank" source_value="0.0" value="0" />
     <capacity source="rank" source_value="0.6" value="1" />
   </weapon>
 
   <weapon file="m60e4.weapon">
-    <commonness value="0.0" in_stock="0" />
+    <commonness value="0.00004" in_stock="0" />
     <capacity source="rank" source_value="0.0" value="0" />
     <capacity source="rank" source_value="0.6" value="1" />
   </weapon>
@@ -527,12 +527,12 @@
     <capacity source="rank" source_value="0.35" value="1" />
   </weapon>
   <weapon file="fal.weapon">
-    <commonness value="0.0" in_stock="0" />
+    <commonness value="0.0002" in_stock="0" />
     <capacity source="rank" source_value="0.0" value="0" />
     <capacity source="rank" source_value="0.55" value="1" />
   </weapon>
   <weapon file="fal_bayonet.weapon">
-    <commonness value="0.0" in_stock="0" />
+    <commonness value="0.0002" in_stock="0" />
     <capacity source="rank" source_value="0.0" value="0" />
     <capacity source="rank" source_value="0.55" value="1" />
   </weapon>
@@ -551,7 +551,7 @@
     <capacity source="rank" source_value="0.2" value="1" />
   </weapon>
   <weapon file="m16a4_support.weapon">
-    <commonness value="0.0" in_stock="0" />
+    <commonness value="0.00002" in_stock="0" />
     <capacity source="rank" source_value="0.0" value="0" />
     <capacity source="rank" source_value="0.1" value="1" />
   </weapon>
@@ -573,7 +573,7 @@
     <capacity source="rank" source_value="0.4" value="1" />
    </weapon>
    <weapon file="enforcer.weapon" >
-    <commonness value="0.0" in_stock="0" />
+    <commonness value="0.0001" in_stock="0" />
     <capacity source="rank" source_value="0.0" value="0" />
     <capacity source="rank" source_value="0.3" value="1" />
    </weapon>
@@ -606,7 +606,7 @@
 <!-- CB#4 -->
 
   <weapon file="tkb059.weapon">
-    <commonness value="0.0" in_stock="0" />
+    <commonness value="0.00001" in_stock="0" />
     <capacity source="rank" source_value="0.0" value="0" />
     <capacity source="rank" source_value="0.3" value="1" />
   </weapon>
@@ -621,12 +621,12 @@
     <capacity source="rank" source_value="0.2" value="1" />
   </weapon>
   <weapon file="g11.weapon">
-    <commonness value="0.0" in_stock="0" />
+    <commonness value="0.000025" in_stock="0" />
     <capacity source="rank" source_value="0.0" value="0" />
     <capacity source="rank" source_value="0.7" value="1" />
   </weapon>
   <weapon file="g11_alt.weapon">
-    <commonness value="0.0" in_stock="0" />
+    <commonness value="0.000025" in_stock="0" />
     <capacity source="rank" source_value="0.0" value="0" />
     <capacity source="rank" source_value="0.7" value="1" />
   </weapon>
@@ -666,7 +666,7 @@
   <weapon file="flamer_tank_mg.weapon" />
   <weapon file="flamer_tank_cannon.weapon" />
   <weapon file="suomi.weapon">
-    <commonness value="0.0" in_stock="0" />
+    <commonness value="0.00003" in_stock="0" />
     <capacity source="rank" source_value="0.0" value="0" />
     <capacity source="rank" source_value="0.3" value="1" />
   </weapon>
@@ -683,7 +683,7 @@
     <capacity source="rank" source_value="0.3" value="1" />
   </weapon>
  	<weapon file="p416.weapon">
-    <commonness value="0.0" in_stock="0" />
+    <commonness value="0.00003" in_stock="0" />
     <capacity source="rank" source_value="0.0" value="0" />
     <capacity source="rank" source_value="0.9" value="1" />
   </weapon>
@@ -751,7 +751,7 @@
     <capacity source="rank" source_value="0.3" value="1" />
   </weapon>
   <weapon file="ares_shrike_s.weapon">
-    <commonness value="0.0" in_stock="0" />
+    <commonness value="0.0003" in_stock="0" />
     <capacity source="rank" source_value="0.0" value="0" />
     <capacity source="rank" source_value="0.5" value="1" />
   </weapon>
@@ -797,12 +797,12 @@
     <capacity source="rank" source_value="0.5" value="1" />
   </weapon>
   <weapon file="g36_w_ag36.weapon">
-    <commonness value="0.0" in_stock="0" />
+    <commonness value="0.0001" in_stock="0" />
     <capacity source="rank" source_value="0.0" value="0" />
     <capacity source="rank" source_value="0.5" value="1" />
   </weapon>
   <weapon file="g36_w_ag36_g.weapon">
-    <commonness value="0.0" in_stock="0" />
+    <commonness value="0.0001" in_stock="0" />
     <capacity source="rank" source_value="0.0" value="0" />
     <capacity source="rank" source_value="0.5" value="1" />
   </weapon>
@@ -845,12 +845,12 @@
     <capacity source="rank" source_value="2.0" value="1" />
   </weapon>
   <weapon file="dp28.weapon">
-    <commonness value="0.0" in_stock="0" />
+    <commonness value="0.000025" in_stock="0" />
     <capacity source="rank" source_value="0.0" value="0" />
     <capacity source="rank" source_value="0.5" value="1" />
   </weapon>
   <weapon file="dp28_s.weapon">
-    <commonness value="0.0" in_stock="0" />
+    <commonness value="0.000025" in_stock="0" />
     <capacity source="rank" source_value="0.0" value="0" />
     <capacity source="rank" source_value="0.5" value="1" />
   </weapon>
@@ -865,7 +865,7 @@
     <capacity source="rank" source_value="1.0" value="1" />
   </weapon>
   <weapon file="fd338.weapon">
-    <commonness value="0.0" in_stock="0" />
+    <commonness value="0.0002" in_stock="0" />
     <capacity source="rank" source_value="0.0" value="0" />
     <capacity source="rank" source_value="0.9" value="1" />
   </weapon>

--- a/weapons/invasion_all_weapons.xml
+++ b/weapons/invasion_all_weapons.xml
@@ -74,7 +74,7 @@
   <weapon file="medikit.weapon" />
   <weapon file="tow.weapon" />
   <weapon file="vss_vintorez.weapon">
-    <commonness value="0.0002" in_stock="0" />
+    <commonness value="0.000001" in_stock="0" />
     <capacity source="rank" source_value="0.0" value="0" />
     <capacity source="rank" source_value="0.4" value="1" />
   </weapon>
@@ -855,7 +855,7 @@
     <capacity source="rank" source_value="0.5" value="1" />
   </weapon>
   <weapon file="qbz95.weapon">
-    <commonness value="0.0" in_stock="0" />
+    <commonness value="0.000025" in_stock="0" />
     <capacity source="rank" source_value="0.0" value="0" />
     <capacity source="rank" source_value="1.0" value="1" />
   </weapon>
@@ -870,7 +870,7 @@
     <capacity source="rank" source_value="0.9" value="1" />
   </weapon>
   <weapon file="fd338sd.weapon">
-    <commonness value="0.0" in_stock="0" />
+    <commonness value="0.000001" in_stock="0" />
     <capacity source="rank" source_value="0.0" value="0" />
     <capacity source="rank" source_value="0.9" value="1" />
   </weapon>

--- a/weapons/m16a4_support.weapon
+++ b/weapons/m16a4_support.weapon
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<weapon file="base_primary_rare.weapon" key="m16a4_support.weapon">
+    <tag name="assault" />
+    <specification 
+  retrigger_time="0.113" 
+  accuracy_factor="1.0" 
+  sustained_fire_grow_step="0.3" 
+  sustained_fire_diminish_rate="1.40" 
+  magazine_size="100" 
+  can_shoot_standing="0"
+  can_shoot_crouching="1" 
+  suppressed="0" 
+  name="M16A4 - shield and scope" 
+  class="0" 
+  projectile_speed="100.0"
+  sight_range_modifier="1.2"
+  barrel_offset="0.4" />
+
+    <animation key="recoil" ref="12" />
+    <animation key="recoil" ref="13" />
+    <animation key="recoil" ref="14" />
+    <animation state_key="reload" animation_key="reloading, m16a4" />
+	<animation key="reload" stance_key="prone" animation_key="reloading, ar1, prone" />	
+
+    <sound key="fire" fileref="m16a4_shot.wav" pitch_variety="0.05" volume="0.5" />
+    <sound key="magazine_out" fileref="rifle_clip_out.wav" />
+    <sound key="magazine_in" fileref="rifle_clip_in.wav" />
+    <sound key="cycle" fileref="rifle_chamber.wav" />
+    <sound class="impact" fileref="rifle_drop.wav" />    
+    <model filename="m16a4_support.xml" />
+
+    <hud_icon filename="hud_m16a4_support.png" />
+    <commonness value="0.00002" can_respawn_with="0" in_stock="0" />
+    <inventory encumbrance="10.0" price="90.0" />
+	
+    <capacity value="0" source="rank" source_value="0.0" />
+    <capacity value="1" source="rank" source_value="0.1" />
+
+    <weak_hand_hold offset="0.2" />
+    <projectile file="bullet.projectile">
+        <result class="hit"  kill_probability="0.5" kill_decay_start_time="0.34" kill_decay_end_time="0.67" />
+    </projectile>
+    
+    <stance state_key="running" accuracy="0.3" />
+    <stance state_key="walking" accuracy="0.675" />
+    <stance state_key="crouch_moving" accuracy="0.75" />
+    <stance state_key="prone_moving" accuracy="0.3" />
+
+    <stance state_key="standing" accuracy="0.8" />
+    <stance state_key="crouching" accuracy="0.85" />
+    <stance state_key="prone" accuracy="0.94" />
+
+    <shield offset="-0.55 0.0 0" extent="0.2 0.6 0.6" usable_for_cover="0"/>
+    <modifier class="speed" value="-0.08" />    
+</weapon>

--- a/weapons/m60e4.weapon
+++ b/weapons/m60e4.weapon
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<weapon file="base_primary_rare.weapon" key="m60e4.weapon">
+    <tag name="machine gun" />
+    <specification 
+  retrigger_time="0.1" 
+  accuracy_factor="0.725" 
+  spread_range="0.175"
+  sustained_fire_grow_step="2.5" 
+  sustained_fire_diminish_rate="1.15" 
+  magazine_size="100" 
+  can_shoot_standing="1" 
+  can_shoot_crouching="1" 
+  suppressed="0" 
+  name="M60" 
+  class="0" 
+  projectile_speed="100.0" />
+
+	<!-- Balanced in several ways:-->
+	<!-- Accuracy is low, recoil moderate -->
+	<!-- Movement speed is slow -->
+	<!-- Rate of Fire is moderately slow -->
+	<!-- Velocity is low -->
+	<!-- Despite all this, magazine capacity is large and damage is very high. -->
+
+
+ 	<animation state_key="recoil" animation_key="recoil, hip fire" />
+ 	<animation state_key="recoil" animation_key="recoil2, hip fire" />
+ 	<animation state_key="recoil" animation_key="recoil3, hip fire" />
+	<animation key="recoil" stance_key="over_wall" ref="12" />
+	<animation key="recoil" stance_key="over_wall" ref="13" />
+	<animation key="recoil" stance_key="over_wall" ref="14" />
+  <animation state_key="hold" animation_key="hold, lmg" />
+  <animation key="reload" ref="33" />
+  <animation key="hold_on_wall" ref="1" />
+	<animation state_key="walking" animation_key="walking, hip fire" />
+	<animation state_key="crouching" animation_key="crouch, hold, hip fire" />
+	<animation state_key="crouch_moving" animation_key="crouching forwards, hip fire" />
+    
+    <sound key="fire" fileref="m60_shot.wav" pitch_variety="0.05" volume="0.5" />
+    <sound key="magazine_out" fileref="mg_clip_out.wav" />
+    <sound key="magazine_in" fileref="mg_clip_in.wav" />
+    <sound key="cycle" fileref="rifle_chamber.wav" />
+    <sound class="impact" fileref="rifle_drop.wav" />
+    <model filename="m60e4.xml" />
+
+    <hud_icon filename="hud_m60e4.png" />
+    <commonness value="0.00004" can_respawn_with="0" in_stock="0"/>
+    <inventory encumbrance="10.0" price="700.0" />
+
+    <weak_hand_hold offset="0.4" />
+    <projectile file="bullet.projectile">
+        <result class="hit" kill_probability="0.71" kill_decay_start_time="0.35" kill_decay_end_time="0.65" />
+    </projectile>
+    <modifier class="speed" value="-0.11" />
+</weapon>

--- a/weapons/p416.weapon
+++ b/weapons/p416.weapon
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<weapon file="base_primary_rare.weapon" key="p416.weapon">
+    <tag name="assault" />
+    <specification 
+  retrigger_time="0.113" 
+  accuracy_factor="1.0" 
+  sustained_fire_grow_step="0.4" 
+  sustained_fire_diminish_rate="1.2" 
+  magazine_size="30" 
+  can_shoot_standing="1" 
+  suppressed="1" 
+  name="P416" 
+  class="0" 
+  projectile_speed="100.0"
+  sight_range_modifier="1.1" 
+  barrel_offset="0.4" />
+
+    <animation key="recoil" ref="12" />
+    <animation key="recoil" ref="13" />
+    <animation key="recoil" ref="14" />
+    <animation state_key="reload" animation_key="reloading, m16a4" />
+	<animation key="reload" stance_key="prone" animation_key="reloading, ar1, prone" />	
+	
+
+    <animation state_key="celebrate_shoot" animation_key="celebrating, shooting" />
+
+    <sound key="fire" fileref="p416_shot.wav" pitch_variety="0.05" volume="0.5" />
+    <sound key="magazine_out" fileref="rifle_clip_out.wav" />
+    <sound key="magazine_in" fileref="rifle_clip_in.wav" />
+    <sound key="cycle" fileref="rifle_chamber.wav" />
+    <sound class="impact" fileref="rifle_drop.wav" />    
+    <model filename="p416.xml" />
+
+    <hud_icon filename="hud_p416.png" />
+    <inventory encumbrance="10.0" price="416.0" />
+    <commonness value="0.00003" can_respawn_with="0" in_stock="0"/>
+	
+    <capacity value="0" source="rank" source_value="0.0" />
+    <capacity value="1" source="rank" source_value="0.9" /> 	
+
+    <weak_hand_hold offset="0.2" />
+    <projectile file="bullet.projectile">
+        <result class="hit"  kill_probability="0.52" kill_decay_start_time="0.30" kill_decay_end_time="0.62" />
+    </projectile>
+    
+    <stance state_key="running" accuracy="0.3" />
+    <stance state_key="walking" accuracy="0.675" />
+    <stance state_key="crouch_moving" accuracy="0.75" />
+    <stance state_key="prone_moving" accuracy="0.3" />
+
+    <stance state_key="standing" accuracy="0.85" />
+    <stance state_key="crouching" accuracy="0.9" />
+    <stance state_key="prone" accuracy="0.93" />
+    
+    <modifier class="speed" value="-0.04" />
+</weapon>

--- a/weapons/qbz95.weapon
+++ b/weapons/qbz95.weapon
@@ -30,7 +30,7 @@
     <model filename="qbz95.xml" />
 
     <hud_icon filename="hud_qbz95.png" />
-    <commonness value="0.0" can_respawn_with="0" in_stock="0" />
+    <commonness value="0.000025" can_respawn_with="0" in_stock="0" />
     <inventory encumbrance="10.0" price="280" />
 
     <weak_hand_hold offset="0.0" />

--- a/weapons/qbz95.weapon
+++ b/weapons/qbz95.weapon
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<weapon file="base_primary_rare.weapon" key="qbz95.weapon">
+    <tag name="assault" />
+    <specification 
+  retrigger_time="0.12" 
+  accuracy_factor="0.95" 
+  spread_range="0.15"
+  sustained_fire_grow_step="0.42" 
+  sustained_fire_diminish_rate="1.3" 
+  magazine_size="30" 
+  can_shoot_standing="1" 
+  suppressed="0" 
+  name="qbz-95" 
+  class="0" 
+  projectile_speed="95.0" 
+  barrel_offset="0.2" />
+
+    <next_in_chain key="qbz95_us.weapon" share_ammo="0" />
+
+    <animation key="recoil" ref="12" />
+    <animation key="recoil" ref="13" />
+    <animation key="recoil" ref="14" />
+    <animation state_key="reload" animation_key="reloading, famasg1" />
+    <animation state_key="next_in_chain_in" animation_key="switch fire mode" /> 
+    <sound key="fire" fileref="qbz95_shot.wav" pitch_variety="0.0" volume="0.1" />
+    <sound key="magazine_out" fileref="rifle_clip_out.wav" />
+    <sound key="magazine_in" fileref="rifle_clip_in.wav" />
+    <sound key="cycle" fileref="rifle_chamber.wav" />
+    <sound class="impact" fileref="rifle_drop.wav" />
+    <model filename="qbz95.xml" />
+
+    <hud_icon filename="hud_qbz95.png" />
+    <commonness value="0.0" can_respawn_with="0" in_stock="0" />
+    <inventory encumbrance="10.0" price="280" />
+
+    <weak_hand_hold offset="0.0" />
+    <projectile file="bullet.projectile">
+        <result class="hit"  kill_probability="0.53" kill_decay_start_time="0.37" kill_decay_end_time="0.63" />
+    </projectile>
+
+    <modifier class="speed" value="-0.08" />
+</weapon>

--- a/weapons/suomi.weapon
+++ b/weapons/suomi.weapon
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<weapon file="base_primary_rare.weapon" key="suomi.weapon">
+    <tag name="assault" />
+    <specification 
+    retrigger_time="0.08" 
+    accuracy_factor="0.9" 
+    sustained_fire_grow_step="0.36" 
+    sustained_fire_diminish_rate="3.0" 
+    magazine_size="71" 
+    can_shoot_standing="1" 
+    suppressed="0" 
+    name="KP-31 Suomi" 
+    class="0" 
+    projectile_speed="100.0"
+	barrel_offset="0.2"
+	/>
+    <animation key="recoil" ref="12" />
+    <animation key="recoil" ref="13" />
+    <animation key="recoil" ref="14" />
+    <animation state_key="reload" animation_key="reloading, aks74u" />
+	<animation key="reload" stance_key="prone" animation_key="reloading, ar1, prone" />	
+	
+    <sound key="fire" fileref="suomi_shot.wav" pitch_variety="0.02" volume="0.25" />
+    <sound key="magazine_out" fileref="rifle_clip_out.wav" />
+    <sound key="magazine_in" fileref="rifle_clip_in.wav" />
+    <sound key="cycle" fileref="rifle_chamber.wav" />
+    <sound class="impact" fileref="rifle_drop.wav" />
+    <model filename="suomi.xml" />
+
+    <hud_icon filename="hud_suomi.png" />
+    <commonness value="0.00003" can_respawn_with="0" in_stock="0" />
+    <inventory encumbrance="10.0" price="300.0" />
+	
+	<capacity value="0" source="rank" source_value="0.0" />
+	<capacity value="1" source="rank" source_value="0.3" />	
+
+    <projectile file="bullet.projectile">
+        <result class="hit" kill_probability="0.5" kill_decay_start_time="0.30" kill_decay_end_time="0.45" />
+    </projectile>
+
+    <stance state_key="walking" accuracy="0.8" /> <!--- This is a special feature for the gun, making walking almost as accurate as standing --->	
+
+</weapon>

--- a/weapons/tkb059.weapon
+++ b/weapons/tkb059.weapon
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<weapon file="base_primary_rare.weapon" key="tkb059.weapon">
+    <tag name="assault" />
+    <specification 
+  retrigger_time="0.123" 
+  accuracy_factor="0.96" 
+  sustained_fire_grow_step="0.50" 
+  sustained_fire_diminish_rate="1.1" 
+  magazine_size="30" 
+  can_shoot_standing="1" 
+  suppressed="0" 
+  name="TKB-059" 
+  class="0" 
+  projectile_speed="100.0"
+  projectiles_per_shot="3" />
+
+    <animation key="recoil" ref="12" />
+    <animation key="recoil" ref="13" />
+    <animation key="recoil" ref="14" />
+    <animation state_key="reload" animation_key="reloading, f2000" />
+	<animation key="reload" stance_key="prone" animation_key="reloading, ar1, prone" />	
+	
+
+    <animation state_key="celebrate_shoot" animation_key="celebrating, shooting" />
+
+    <sound key="fire" fileref="tkb059_shot.wav" pitch_variety="0.06" volume="0.5" />
+    <sound key="magazine_out" fileref="rifle_clip_out.wav" />
+    <sound key="magazine_in" fileref="rifle_clip_in.wav" />
+    <sound key="cycle" fileref="rifle_chamber.wav" />
+    <sound class="impact" fileref="rifle_drop.wav" />
+    <model filename="tkb059.xml" />
+
+    <hud_icon filename="hud_tkb059.png" />
+    <commonness value="0.00001" can_respawn_with="0" in_stock="0" />
+    <inventory encumbrance="10.0" price="630.0" />
+
+    <projectile file="bullet.projectile">
+	    <result class="hit" kill_probability="0.5" kill_decay_start_time="0.25" kill_decay_end_time="0.58" />
+    </projectile>
+    <modifier class="speed" value="-0.03" />
+</weapon>

--- a/weapons/vss_vintorez.weapon
+++ b/weapons/vss_vintorez.weapon
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<weapon file="base_primary_rare.weapon" key="vss_vintorez.weapon">
+    <tag name="stealth" />
+    <specification 
+	retrigger_time="0.2" 
+	accuracy_factor="0.9" 
+	sustained_fire_grow_step="3.0" 
+	sustained_fire_diminish_rate="3.0" 
+	magazine_size="20" 
+	can_shoot_standing="1" 
+	suppressed="1" 
+	name="VSS Vintorez" 
+	class="0" 
+	burst_shots="1"
+	reload_one_at_a_time="0" 
+	sight_range_modifier="1.3" 
+	projectile_speed="120.0" 
+	barrel_offset="0.4" 
+	projectiles_per_shot="1" />
+
+    <animation key="recoil" ref="27" />
+	<animation key="recoil" stance_key="prone" animation_key="recoil1, big, prone" />
+    <animation key="cycle" ref="30" />
+	<animation key="cycle" stance_key="prone" animation_key="bolt cycle, prone" />
+    <animation state_key="reload" animation_key="reloading, vss_vintorez" />
+	<animation key="reload" stance_key="prone" animation_key="reloading, ar2, prone" />
+
+    <sound key="fire" fileref="vss_vintorez_shot.wav" pitch_variety="0.05" volume="0.55" />
+    <sound key="cycle" fileref="sniper_cycle.wav" />
+    <sound key="magazine_out" fileref="sniper_clip_out.wav" />
+    <sound key="magazine_in" fileref="sniper_clip_in.wav" />
+    <sound key="cycle_out" fileref="sniper_cycle_out.wav" />
+    <sound key="cycle_in" fileref="sniper_cycle_in.wav" />
+    <sound class="impact" fileref="rifle_drop.wav" />
+
+    <model filename="vss_vintorez.xml" />
+    <hud_icon filename="hud_vss_vintorez.png" />
+    <commonness value="0.000001" can_respawn_with="0" in_stock="0" />
+    <inventory encumbrance="11.0" price="200.0" />
+
+    <projectiles_per_shot value="1" />
+    <weak_hand_hold offset="0.3" />
+
+    <projectile file="bullet.projectile">
+        <result 
+		class="hit" 
+		kill_probability="0.8" 
+		kill_decay_start_time="0.65" 
+		kill_decay_end_time="1.0" />
+    </projectile>
+    
+    <stance state_key="running" accuracy="0.1" />
+    <stance state_key="walking" accuracy="0.5" />
+    <stance state_key="crouch_moving" accuracy="0.1" />
+    <stance state_key="standing" accuracy="0.8" />
+    <stance state_key="crouching" accuracy="0.9" />
+    <stance state_key="prone" accuracy="1.0" /> 
+    <stance state_key="prone_moving" accuracy="0.1" />
+    <stance state_key="over_wall" accuracy="0.9" />
+    
+    <modifier class="speed" value="-0.05" />    
+
+</weapon>

--- a/weapons/xm25.weapon
+++ b/weapons/xm25.weapon
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<weapon file="base_primary_rare.weapon" key="xm25.weapon">
+    <tag name="assault" />
+
+    <specification 
+  retrigger_time="1.7" 
+  accuracy_factor="1.0" 
+  sustained_fire_grow_step="2.3" 
+  sustained_fire_diminish_rate="0.5" 
+  magazine_size="4" 
+  can_shoot_standing="1" 
+  suppressed="0" 
+  name="XM-25" 
+  class="0" 
+  sight_range_modifier="1.2"  
+  projectile_speed="40.0"
+  projectiles_per_shot="1"  
+  barrel_offset="0.3" 
+/>
+
+	<next_in_chain key="xm25_r.weapon" share_ammo="1" />
+
+	<!--<addon_model filename="backpack_small.xml" />-->
+
+    <!--     <ballistics near_far_distance="20.0" speed_estimation_near="25.0" speed_estimation_far="25.0" max_speed="50.0" randomness="0.0" />    -->
+    <!-- original <ballistics curve_height="3.6" near_far_distance="100.0" speed_estimation_near="40.0" speed_estimation_far="40.0" max_speed="40.0" randomness="0.0" tweak_factor="1.1" />    --> 
+
+    <!-- auto detonating conversion by Unit G17									max_speed ~ max range -->
+    <ballistics curve_height="2.0" near_far_distance="0.0" speed_estimation_near="40.0" speed_estimation_far="40.0" max_speed="60.0" randomness="0.0" tweak_factor="1.94" /> 
+
+
+    <animation key="recoil" ref="12" />
+    <animation key="recoil" ref="13" />
+    <animation key="recoil" ref="14" />
+    <animation state_key="reload" animation_key="reloading, m79" />
+    <animation state_key="next_in_chain_in" animation_key="switch fire mode" />    
+    
+    <sound key="fire" fileref="xm25_shot.wav" pitch_variety="0.1" volume="1.0" />
+    <sound key="magazine_out" fileref="rifle_clip_out.wav" />
+    <sound key="magazine_in" fileref="rifle_clip_in.wav" />
+    <sound key="cycle" fileref="rifle_chamber.wav" />
+    <sound class="impact" fileref="rifle_drop.wav" />    
+ 
+    <model filename="xm25.xml" />
+  
+    <projectile file="xm25.projectile" />
+    <weak_hand_hold offset="0.005" />
+
+    <capacity value="0" source="rank" source_value="0.0" />
+    <capacity value="1" source="rank" source_value="0.4" />
+
+    <hud_icon filename="hud_xm25.png" />
+    <commonness value="0.0005" in_stock="1" can_respawn_with="0" />
+    <inventory encumbrance="12.0" price="200.0" />
+
+    <effect class="muzzle" ref="LawMuzzle" />
+    <effect class="muzzle" ref="UpDust" />
+
+    <stance state_key="running" accuracy="0.13" />
+    <stance state_key="walking" accuracy="0.4" />
+    <stance state_key="crouch_moving" accuracy="0.15" />
+    <stance state_key="prone_moving" accuracy="0.02" />
+
+    <stance state_key="standing" accuracy="0.80" />
+    <stance state_key="crouching" accuracy="0.92" />
+    <stance state_key="prone" accuracy="1.0" />
+    <modifier class="speed" value="-0.12" />    
+
+</weapon>


### PR DESCRIPTION
- Elites, Grenadiers, EOD Elites, and Lone Wolves now have the appropriate box weapons added to their inventories
- Also moved existing weapons between the different AI types as appropriate
- Modified weapon commonness values to fit into the new AI inventories
- Disabled friendly fire for specific explosive weapons added to Grenadiers